### PR TITLE
CLN: move isort config to pyproject.toml (#42637)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,17 @@ module = [
   "pandas.tests.test_expressions",
 ]
 ignore_errors = true
+
+# To be kept consistent with "Import Formatting" section in contributing.rst
+[tool.isort]
+known_pre_libs = "pandas._config"
+known_pre_core = ["pandas._libs", "pandas._typing", "pandas.util._*", "pandas.compat", "pandas.errors"]
+known_dtypes = "pandas.core.dtypes"
+known_post_core = ["pandas.tseries", "pandas.io", "pandas.plotting"]
+sections = ["FUTURE", "STDLIB", "THIRDPARTY" ,"PRE_LIBS" , "PRE_CORE", "DTYPES", "FIRSTPARTY", "POST_CORE", "LOCALFOLDER"]
+profile = "black"
+combine_as_imports = true
+force_grid_wrap = 2
+force_sort_within_sections = true
+skip_glob = "env"
+skip = "pandas/__init__.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -190,18 +190,3 @@ exclude_lines =
 
 [coverage:html]
 directory = coverage_html_report
-
-# To be kept consistent with "Import Formatting" section in contributing.rst
-[isort]
-known_pre_libs = pandas._config
-known_pre_core = pandas._libs,pandas._typing,pandas.util._*,pandas.compat,pandas.errors
-known_dtypes = pandas.core.dtypes
-known_post_core = pandas.tseries,pandas.io,pandas.plotting
-sections = FUTURE,STDLIB,THIRDPARTY,PRE_LIBS,PRE_CORE,DTYPES,FIRSTPARTY,POST_CORE,LOCALFOLDER
-profile = black
-combine_as_imports = True
-line_length = 88
-force_grid_wrap = True
-force_sort_within_sections = True
-skip_glob = env,
-skip = pandas/__init__.py


### PR DESCRIPTION
* CLN: move isort config to pyproject.toml

* clean

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
